### PR TITLE
Task-2960870686380800: 日期时间类型的用户侧一致性改造

### DIFF
--- a/packages/basic/src/Formatters/DateFormatter.ts
+++ b/packages/basic/src/Formatters/DateFormatter.ts
@@ -1,3 +1,4 @@
+import { format } from 'date-fns';
 import Formatter from './Formatter';
 
 /**
@@ -40,6 +41,10 @@ export class DateFormatter extends Formatter {
 
     format(value, pattern) {
         pattern = pattern || this.pattern;
+
+        if (pattern === `yyyy-MM-dd'T'HH:mm:ss.SSSxxx`) {
+            return format(value, pattern);
+        }
 
         if (value && !isNaN(value))
             value = +value;

--- a/packages/basic/src/init/dataTypes/tools.ts
+++ b/packages/basic/src/init/dataTypes/tools.ts
@@ -1,4 +1,4 @@
-import { formatISO } from "date-fns";
+import { format } from "date-fns";
 import momentTZ from "moment-timezone";
 import moment from "moment";
 
@@ -632,7 +632,7 @@ export const toString = (
     } else if (typeKey === "nasl.core.DateTime") {
       str = momentTZ
         .tz(safeNewDate(variable), getAppTimezone(tz))
-        .format("YYYY-MM-DD HH:mm:ss");
+        .format("YYYY-MM-DDTHH:mm:ss.SSSZ");
     }
     if (tabSize > 0) {
       if (["nasl.core.String", "nasl.core.Text"].includes(typeKey)) {
@@ -910,15 +910,11 @@ export const fromString = (variable, typeKey) => {
   const isPrimitive = isDefPrimitive(typeKey);
   const { typeName } = typeDefinition || {};
   // 日期
-  if (typeName === "DateTime" && isValidDate(variable, DateTimeReg)) {
+  if (typeName === "DateTime") {
     const date = safeNewDate(variable);
-    const outputDate = formatISO(date, {
-      format: "extended",
-      // @ts-ignore 忽略吧，我也不知道为什么要传这个
-      fractionDigits: 3,
-    });
+    const outputDate = format(date, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
     return outputDate;
-  } else if (typeName === "Date" && isValidDate(variable, DateReg)) {
+  } else if (typeName === "Date") {
     return moment(safeNewDate(variable)).format('YYYY-MM-DD');
   } else if (typeName === "Time" && TimeReg.test(variable)) {
     // ???

--- a/packages/basic/src/init/utils/helper.ts
+++ b/packages/basic/src/init/utils/helper.ts
@@ -89,6 +89,14 @@ export function convertJSDateInTargetTimeZone(date, tz) {
 }
 
 export const safeNewDate = (dateStr) => {
+  // 如果输入是字符串形式的时间戳，则先转换为时间戳
+  if (typeof dateStr === 'string' && /^\d+$/.test(dateStr)) {
+    const date = new Date(parseInt(dateStr, 10));
+    if (!isNaN(date.getTime())) {
+      return date;
+    }
+  }
+  
   try {
       const res = new Date(dateStr.replaceAll('-', '/'));
       if (['Invalid Date', 'Invalid time value', 'invalid date'].includes(res.toString())) {

--- a/packages/basic/src/init/utils/index.ts
+++ b/packages/basic/src/init/utils/index.ts
@@ -7,7 +7,6 @@ import {
   subDays,
   addMonths,
   format,
-  formatRFC3339,
   isValid,
   differenceInYears,
   differenceInQuarters,
@@ -190,13 +189,13 @@ export const utils = {
       // v3.3 老应用升级的场景，UTC 零时区，零时区展示上用 'Z'，后向兼容
       // v3.4 新应用，使用默认时区时选项，tz 为空
       if (!tz) {
-        const d = momentTZ.tz(v, "UTC").format("YYYY-MM-DDTHH:mm:ss.SSS") + "Z";
+        const d = momentTZ.tz(v, "UTC").format("YYYY-MM-DDTHH:mm:ss.SSSZ");
         return JSON.stringify(d);
       }
       // 新应用，设置为零时区，零时区展示上用 'Z'，后向兼容.
       if (tz === "UTC") {
         // TODO: 想用 "+00:00" 展示零时区
-        const d = momentTZ.tz(v, "UTC").format("YYYY-MM-DDTHH:mm:ss.SSS") + "Z";
+        const d = momentTZ.tz(v, "UTC").format("YYYY-MM-DDTHH:mm:ss.SSSZ");
         return JSON.stringify(d);
       }
       // 新应用，设置为其他时区
@@ -1029,7 +1028,7 @@ export const utils = {
         break;
     }
     if (typeof dateString === "object" || this.isInputValidNaslDateTime(dateString)) {
-      return format(addDate, "yyyy-MM-dd HH:mm:ss");
+      return format(addDate, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
     } else {
       return format(addDate, "yyyy-MM-dd");
     }
@@ -1097,7 +1096,7 @@ export const utils = {
     );
     if (typeof startdatetr === "object" || startdatetr.includes("T")) {
       return filtereddate.map((date) =>
-        moment(date).format("YYYY-MM-DD HH:mm:ss")
+        moment(date).format("YYYY-MM-DDTHH:mm:ss.SSSZ")
       );
     } else {
       return filtereddate.map((date) => moment(date).format("YYYY-MM-DD"));
@@ -1232,7 +1231,7 @@ export const utils = {
   Convert(value, tyAnn) {
     if (tyAnn && tyAnn.typeKind === "primitive") {
       if (tyAnn.typeName === "DateTime")
-        return formatRFC3339(safeNewDate(value));
+        return format(safeNewDate(value), "yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
       else if (tyAnn.typeName === "Date")
         return format(safeNewDate(value), "yyyy-MM-dd");
       else if (tyAnn.typeName === "Time") {

--- a/packages/core/src/plugins/Formatters/DateFormatter.js
+++ b/packages/core/src/plugins/Formatters/DateFormatter.js
@@ -1,4 +1,6 @@
+import { format } from 'date-fns';
 import Formatter from './Formatter';
+
 
 /**
  * @TODO: use moment or some other library
@@ -38,6 +40,10 @@ export class DateFormatter extends Formatter {
 
     format(value, pattern) {
         pattern = pattern || this.pattern;
+
+        if (pattern === `yyyy-MM-dd'T'HH:mm:ss.SSSxxx`) {
+            return format(value, pattern);
+        }
 
         if (value && !isNaN(value))
             value = +value;

--- a/packages/core/src/plugins/dataTypes/tools.js
+++ b/packages/core/src/plugins/dataTypes/tools.js
@@ -1,4 +1,4 @@
-import { formatISO } from "date-fns";
+import { format } from "date-fns";
 import { getAppTimezone } from "../utils/timezone";
 import { safeNewDate } from '../utils';
 const momentTZ = require("moment-timezone");
@@ -630,7 +630,7 @@ export const toString = (
     } else if (typeKey === "nasl.core.DateTime") {
       str = momentTZ
         .tz(safeNewDate(variable), getAppTimezone(tz))
-        .format("YYYY-MM-DD HH:mm:ss");
+        .format("YYYY-MM-DDTHH:mm:ss.SSSZ");
     }
     if (tabSize > 0) {
       if (["nasl.core.String", "nasl.core.Text"].includes(typeKey)) {
@@ -911,14 +911,11 @@ export const fromString = (variable, typeKey) => {
   const isPrimitive = isDefPrimitive(typeKey);
   const { typeName } = typeDefinition || {};
   // 日期
-  if (typeName === "DateTime" && isValidDate(variable, DateTimeReg)) {
+  if (typeName === "DateTime") {
     const date = safeNewDate(variable);
-    const outputDate = formatISO(date, {
-      format: "extended",
-      fractionDigits: 3,
-    });
+    const outputDate = format(date, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
     return outputDate;
-  } else if (typeName === "Date" && isValidDate(variable, DateReg)) {
+  } else if (typeName === "Date") {
     return moment(safeNewDate(variable)).format("YYYY-MM-DD");
   } else if (typeName === "Time" && TimeReg.test(variable)) {
     // ???

--- a/packages/core/src/plugins/utils/index.js
+++ b/packages/core/src/plugins/utils/index.js
@@ -6,7 +6,6 @@ import {
   subDays,
   addMonths,
   format,
-  formatRFC3339,
   isValid,
   differenceInYears,
   differenceInQuarters,
@@ -71,6 +70,14 @@ let enumsMap = {};
 let dataTypesMap = {}
 
 export const safeNewDate = (dateStr) => {
+  // 如果输入是字符串形式的时间戳，则先转换为时间戳
+  if (typeof dateStr === 'string' && /^\d+$/.test(dateStr)) {
+    const date = new Date(parseInt(dateStr, 10));
+    if (!isNaN(date.getTime())) {
+      return date;
+    }
+  }
+  
   try {
       const res = new Date(dateStr.replaceAll('-', '/'));
       if (['Invalid Date', 'Invalid time value', 'invalid date'].includes(res.toString())) {
@@ -226,13 +233,13 @@ export const utils = {
       // v3.3 老应用升级的场景，UTC 零时区，零时区展示上用 'Z'，后向兼容
       // v3.4 新应用，使用默认时区时选项，tz 为空
       if (!tz) {
-        const d = momentTZ.tz(v, "UTC").format("YYYY-MM-DDTHH:mm:ss.SSS") + "Z";
+        const d = momentTZ.tz(v, "UTC").format("YYYY-MM-DDTHH:mm:ss.SSSZ");
         return JSON.stringify(d);
       }
       // 新应用，设置为零时区，零时区展示上用 'Z'，后向兼容.
       if (tz === "UTC") {
         // TODO: 想用 "+00:00" 展示零时区
-        const d = momentTZ.tz(v, "UTC").format("YYYY-MM-DDTHH:mm:ss.SSS") + "Z";
+        const d = momentTZ.tz(v, "UTC").format("YYYY-MM-DDTHH:mm:ss.SSSZ");
         return JSON.stringify(d);
       }
       // 新应用，设置为其他时区
@@ -1097,7 +1104,7 @@ export const utils = {
         break;
     }
     if (typeof dateString === "object" || this.isInputValidNaslDateTime(dateString)) {
-      return format(addDate, "yyyy-MM-dd HH:mm:ss");
+      return format(addDate, "yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
     } else {
       return format(addDate, "yyyy-MM-dd");
     }
@@ -1165,7 +1172,7 @@ export const utils = {
     );
     if (typeof startdatetr === "object" || startdatetr.includes("T")) {
       return filtereddate.map((date) =>
-        moment(date).format("YYYY-MM-DD HH:mm:ss")
+        moment(date).format("YYYY-MM-DDTHH:mm:ss.SSSZ")
       );
     } else {
       return filtereddate.map((date) => moment(date).format("YYYY-MM-DD"));
@@ -1300,7 +1307,7 @@ export const utils = {
   Convert(value, typeAnnotation) {
     if (typeAnnotation && typeAnnotation.typeKind === "primitive") {
       if (typeAnnotation.typeName === "DateTime")
-        return formatRFC3339(safeNewDate(value));
+        return format(safeNewDate(value), "yyyy-MM-dd'T'HH:mm:ss.SSSxxx");
       else if (typeAnnotation.typeName === "Date")
         return format(safeNewDate(value), "yyyy-MM-dd");
       else if (typeAnnotation.typeName === "Time") {

--- a/packages/core/tests/unit/plugins/utils/convert.spec.js
+++ b/packages/core/tests/unit/plugins/utils/convert.spec.js
@@ -21,16 +21,55 @@ describe('Convert 函数', () => {
         expect(codewaveUtils.Convert('1.01', { typeKind: 'primitive', typeName: 'Decimal' }))
             .toBe(1.01);
     });
-//     test('Convert 函数，string 到 DateTime', () => {
-//         const str = '2019-09-09 11:00:00';
 
-//         expect(codewaveUtils.Convert(str, { typeKind: 'primitive', typeName: 'DateTime' }))
-//             .toBe('2019-09-09T11:00:00+08:00');
+    test('Convert 函数，时间戳 到 DateTime', () => {
+        const t = '1699952685877';
 
-//         expect(codewaveUtils.ToString('nasl.core.DateTime',
-//                 codewaveUtils.Convert(str, { typeKind: 'primitive', typeName: 'DateTime' })))
-//             .toBe('2019-09-09 11:00:00');
-//     });
+        expect(codewaveUtils.Convert(t, { typeKind: 'primitive', typeName: 'DateTime' }))
+            .toBe('2023-11-14T17:04:45.877+08:00');
+    });
+
+    test('Convert 函数，时间戳 到 DateTime', () => {
+        const t = 1699952685877;
+
+        expect(codewaveUtils.Convert(t, { typeKind: 'primitive', typeName: 'DateTime' }))
+            .toBe('2023-11-14T17:04:45.877+08:00');
+    });
+
+    test('Convert 函数，时间戳 到 DateTime', () => {
+        const t = '2016-03-13T15:00:01.000+00:00';
+
+        expect(codewaveUtils.Convert(t, { typeKind: 'primitive', typeName: 'DateTime' }))
+            .toBe('2016-03-13T23:00:01.000+08:00');
+    });
+
+    test('Convert 函数，时间戳 到 DateTime', () => {
+        const t = '2016-03-13T15:00:01.000';
+
+        expect(codewaveUtils.Convert(t, { typeKind: 'primitive', typeName: 'DateTime' }))
+            .toBe('2016-03-13T15:00:01.000+08:00');
+    });
+
+    test('Convert 函数，时间戳 到 DateTime', () => {
+        const t = '2016-03-13T15:00:01+00:00';
+
+        expect(codewaveUtils.Convert(t, { typeKind: 'primitive', typeName: 'DateTime' }))
+            .toBe('2016-03-13T23:00:01.000+08:00');
+    });
+
+    test('Convert 函数，时间戳 到 DateTime', () => {
+        const t = '2016-03-13T15:00:01';
+
+        expect(codewaveUtils.Convert(t, { typeKind: 'primitive', typeName: 'DateTime' }))
+            .toBe('2016-03-13T15:00:01.000+08:00');
+    });
+
+    test('Convert 函数，时间戳 到 DateTime', () => {
+        const t = '2016-03-13 15:00:01';
+
+        expect(codewaveUtils.Convert(t, { typeKind: 'primitive', typeName: 'DateTime' }))
+            .toBe('2016-03-13T15:00:01.000+08:00');
+    });
 
 //     test('Convert 函数，string 到 Date', () => {
 //         const str = '2019-09-09 11:00:00';

--- a/packages/core/tests/unit/plugins/utils/date-count.spec.js
+++ b/packages/core/tests/unit/plugins/utils/date-count.spec.js
@@ -50,10 +50,10 @@ describe('日期时间计数函数', () => {
         const d2 = new Date('2023-09-24T01:01:56.000Z');
 
         expect(codewaveUtils.GetSpecificDaysOfWeek(d1, d2, [1, 7, 8], 'Asia/Shanghai'))
-            .toEqual(['2023-09-18 00:00:00', '2023-09-24 00:00:00']); // 上海时间是 18 号到 24 号
+            .toEqual(['2023-09-18T00:00:00.000+08:00', '2023-09-24T00:00:00.000+08:00']); // 上海时间是 18 号到 24 号
 
         expect(codewaveUtils.GetSpecificDaysOfWeek(d1, d2, [1, 7, 8], 'America/New_York'))
-            .toEqual(['2023-09-17 00:00:00', '2023-09-18 00:00:00']); // 纽约时间是 17 号到 23 号
+            .toEqual(['2023-09-17T00:00:00.000+08:00', '2023-09-18T00:00:00.000+08:00']); // 纽约时间是 17 号到 23 号
     });
 
     test('GetSpecificDaysOfWeek，DateTime 类型，有时区信息 2，字符串输入', () => {
@@ -61,9 +61,9 @@ describe('日期时间计数函数', () => {
         const d2 = '2023-09-24T01:01:56.000Z';
 
         expect(codewaveUtils.GetSpecificDaysOfWeek(d1, d2, [1, 7, 8], 'Asia/Shanghai'))
-            .toEqual(['2023-09-18 00:00:00', '2023-09-24 00:00:00']); // 上海时间是 18 号到 24 号
+            .toEqual(['2023-09-18T00:00:00.000+08:00', '2023-09-24T00:00:00.000+08:00']); // 上海时间是 18 号到 24 号
 
         expect(codewaveUtils.GetSpecificDaysOfWeek(d1, d2, [1, 7, 8], 'America/New_York'))
-            .toEqual(['2023-09-17 00:00:00', '2023-09-18 00:00:00']); // 纽约时间是 17 号到 23 号
+            .toEqual(['2023-09-17T00:00:00.000+08:00', '2023-09-18T00:00:00.000+08:00']); // 纽约时间是 17 号到 23 号
     });
 });

--- a/packages/core/tests/unit/plugins/utils/serializer.spec.js
+++ b/packages/core/tests/unit/plugins/utils/serializer.spec.js
@@ -5,7 +5,7 @@ describe('序列化函数', () => {
     test('JSON 序列化兼容性测试，无时区', () => {
         const cur = new Date('2023-09-21T09:01:56.000Z');
         // 零时区的现有展示方式
-        expect(codewaveUtils.JsonSerialize(cur, 'UTC')).toBe('"2023-09-21T09:01:56.000Z"');
+        expect(codewaveUtils.JsonSerialize(cur, 'UTC')).toBe('"2023-09-21T09:01:56.000+00:00"');
         // 未来，想用 "+00:00" 展示零时区
         expect(codewaveUtils.JsonSerialize(cur, 'Etc/GMT')).toBe('"2023-09-21T09:01:56.000+00:00"');
     });
@@ -13,7 +13,7 @@ describe('序列化函数', () => {
     test('JSON 序列化兼容性测试，无时区 2，字符串输入', () => {
         const cur = '2023-09-21T09:01:56Z';
         // 零时区的现有展示方式
-        expect(codewaveUtils.JsonSerialize(cur, 'UTC')).toBe('"2023-09-21T09:01:56.000Z"');
+        expect(codewaveUtils.JsonSerialize(cur, 'UTC')).toBe('"2023-09-21T09:01:56.000+00:00"');
         // 未来，想用 "+00:00" 展示零时区
         expect(codewaveUtils.JsonSerialize(cur, 'Etc/GMT')).toBe('"2023-09-21T09:01:56.000+00:00"');
     });
@@ -58,31 +58,31 @@ describe('序列化函数', () => {
         const curTZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
         const cur = new Date('2023-09-21T17:01:56+08:00');
         expect(codewaveUtils.ToString('nasl.core.DateTime', cur))
-            .toBe(momentTZ.tz('2023-09-21T17:01:56+08:00', curTZ).format('YYYY-MM-DD HH:mm:ss'));
+            .toBe(momentTZ.tz('2023-09-21T17:01:56+08:00', curTZ).format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
     });
 
     test('ToString 兼容性测试 2，字符串输入', () => {
         const curTZ = Intl.DateTimeFormat().resolvedOptions().timeZone;
         const cur = '2023-09-21T17:01:56+08:00';
         expect(codewaveUtils.ToString('nasl.core.DateTime', cur))
-            .toBe(momentTZ.tz('2023-09-21T17:01:56+08:00', curTZ).format('YYYY-MM-DD HH:mm:ss'));
+            .toBe(momentTZ.tz('2023-09-21T17:01:56+08:00', curTZ).format('YYYY-MM-DDTHH:mm:ss.SSSZ'));
     });
 
     test('ToString 时区格式化测试', () => {
         {
             const summerTime1 = new Date('2016-03-13T07:00:01Z');
             expect(codewaveUtils.ToString('nasl.core.DateTime', summerTime1, 'America/New_York'))
-                .toBe('2016-03-13 03:00:01');
+                .toBe('2016-03-13T03:00:01.000-04:00');
             expect(codewaveUtils.ToString('nasl.core.DateTime', summerTime1, 'Asia/Shanghai'))
-                .toBe('2016-03-13 15:00:01');
+                .toBe('2016-03-13T15:00:01.000+08:00');
         }
 
         {
             const noSummerTime1 = new Date('2016-03-13T06:59:59Z');
             expect(codewaveUtils.ToString('nasl.core.DateTime', noSummerTime1, 'America/New_York'))
-                .toBe('2016-03-13 01:59:59');
+                .toBe('2016-03-13T01:59:59.000-05:00');
             expect(codewaveUtils.ToString('nasl.core.DateTime', noSummerTime1, 'Asia/Shanghai'))
-                .toBe('2016-03-13 14:59:59');
+                .toBe('2016-03-13T14:59:59.000+08:00');
         }
 
         {
@@ -104,17 +104,17 @@ describe('序列化函数', () => {
         {
             const summerTime1 = '2016-03-13T07:00:01Z';
             expect(codewaveUtils.ToString('nasl.core.DateTime', summerTime1, 'America/New_York'))
-                .toBe('2016-03-13 03:00:01');
+                .toBe('2016-03-13T03:00:01.000-04:00');
             expect(codewaveUtils.ToString('nasl.core.DateTime', summerTime1, 'Asia/Shanghai'))
-                .toBe('2016-03-13 15:00:01');
+                .toBe('2016-03-13T15:00:01.000+08:00');
         }
 
         {
             const noSummerTime1 = '2016-03-13T06:59:59Z';
             expect(codewaveUtils.ToString('nasl.core.DateTime', noSummerTime1, 'America/New_York'))
-                .toBe('2016-03-13 01:59:59');
+                .toBe('2016-03-13T01:59:59.000-05:00');
             expect(codewaveUtils.ToString('nasl.core.DateTime', noSummerTime1, 'Asia/Shanghai'))
-                .toBe('2016-03-13 14:59:59');
+                .toBe('2016-03-13T14:59:59.000+08:00');
         }
     });
 });


### PR DESCRIPTION
1. 前端内置函数，其输入可兼容多种 DateTime 类型的具体格式，但输出格式均使用 JSONSerialize 后的格式 yyyy-MM-dd'T'HH:mm:ss.SSSxxx，把它作为 CodeWave 内部流通的格式。
2. 平台的 Convert 继续支持 unix 时间戳转 DateTime，修复现有的错误行为。
3. 平台的 fromString 需要支持解析 yyyy-MM-dd'T'HH:mm:ss.SSSxxx 格式输入的字符串，可转到 DateTime 类型，修复现有的错误行为。
4. 格式化字符串使用表格中的规范（同 Java），后期提供更好的交互体验。DateFormatter 