### PR TITLE
feat: match for unions & exceptions

### DIFF
--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -13,10 +13,11 @@
     "build": "npm run build:esm && npm run build:cjs && npm run build:umd && npm run build:types",
     "dev": "nodemon --watch src -e 'ts,js,mjs,cjs,json' --exec 'yalc publish --push'",
     "zip": "npm pack",
-    "prepublish": "npm run clean && npm run build:bundle && npm run test",
+    "prepublish": "npm run clean && npm run build && npm run test",
     "test": "jest --coverage",
-    "build": "npm run clean && npm run build:bundle && npm run zip",
-    "clean": "rm -rf dist cjs esm",
+    "prebuild": "npm run clean",
+    "postbuild": "npm run zip",
+    "clean": "rm -rf dist cjs esm typings",
     "deploy": "node scripts/deploy.js"
   },
   "files": [

--- a/packages/basic/package.json
+++ b/packages/basic/package.json
@@ -13,11 +13,10 @@
     "build": "npm run build:esm && npm run build:cjs && npm run build:umd && npm run build:types",
     "dev": "nodemon --watch src -e 'ts,js,mjs,cjs,json' --exec 'yalc publish --push'",
     "zip": "npm pack",
-    "prepublish": "npm run clean && npm run build && npm run test",
+    "prepublish": "npm run clean && npm run build:bundle && npm run test",
     "test": "jest --coverage",
-    "prebuild": "npm run clean",
-    "postbuild": "npm run zip",
-    "clean": "rm -rf dist cjs esm typings",
+    "build": "npm run clean && npm run build:bundle && npm run zip",
+    "clean": "rm -rf dist cjs esm",
     "deploy": "node scripts/deploy.js"
   },
   "files": [

--- a/packages/basic/src/init/dataTypes/tools.ts
+++ b/packages/basic/src/init/dataTypes/tools.ts
@@ -141,7 +141,8 @@ function genConstructor(typeKey, definition, genInitFromSchema) {
         if (Object.prototype.toString.call(parsedValue) === "[object String]" && !defaultCode?.executeCode) {
           parsedValue = `\`${parsedValue.replace(/['"`\\]/g, (m) => `\\${m}`)}\``;
         }
-        const needGenInitFromSchema = typeAnnotation && !["primitive", "union"].includes(typeAnnotation.typeKind);
+        const needGenInitFromSchema =
+          typeAnnotation && !["primitive"].includes(typeAnnotation.typeKind);
         const sortedTypeKey = genSortedTypeKey(typeAnnotation);
         code += `this.${propertyName} = `;
         if (needGenInitFromSchema) {
@@ -200,11 +201,9 @@ export function isInstanceOf(variable, typeKey) {
   const { concept, typeKind, typeNamespace, typeName, typeArguments } = typeDefinition || {};
   const isPrimitive = isDefPrimitive(typeKey);
   if (typeKind === "union") {
-    let matchedIndex = -1;
-    if (Array.isArray(typeArguments)) {
-      matchedIndex = typeArguments.findIndex((typeArg) => isInstanceOf(variable, genSortedTypeKey(typeArg)));
-    }
-    return matchedIndex !== -1;
+    return !!typeArguments?.some((typeArg) =>
+      isInstanceOf(variable, genSortedTypeKey(typeArg))
+    );
   } else if (concept === "Enum") {
     // 枚举
     const { enumItems } = typeDefinition;
@@ -355,6 +354,122 @@ const isTypeMatch = (typeKey, value) => {
   return isMatch;
 };
 
+function exactMatchShapeAgainstDef(value, def: any): boolean {
+  function isMatchForPrimitive(value, ty) {
+    const valueTypeStr = Object.prototype.toString.call(value);
+    // 检查enum类型
+    if (ty.typeKind === "primitive" && ty.concept === "Enum") {
+      return valueTypeStr === "[object String]";
+    }
+    if (ty.typeKind !== "primitive") {
+      return false;
+    }
+    const typeKey = `${ty.typeNamespace}.${ty.typeName}`;
+    return (
+      (ty === "nasl.core.Boolean" && valueTypeStr === "[object Boolean]") ||
+      (isDefNumber(typeKey) && valueTypeStr === "[object Number]") ||
+      (isDefString(typeKey) && valueTypeStr === "[object String]")
+    );
+  }
+  if (!def) {
+    return false;
+  }
+  if (value === null) {
+    return true;
+  }
+  if (def.typeKind === "primitive") {
+    return isMatchForPrimitive(value, def);
+  } else if (def.typeKind === "union") {
+    for (const ty of def.typeArguments) {
+      if (exactMatchShapeAgainstDef(value, ty)) {
+        return true;
+      }
+    }
+    return false;
+  } else if (def.typeKind === "generic") {
+    const typeKey = `${def.typeNamespace}.${def.typeName}`;
+    return isInstanceOf(value, typeKey);
+  } else if (def.properties) {
+    const properties = def.properties;
+    if (properties) {
+      return properties.every((prop) => {
+        const propValue = value[prop.name];
+        if (propValue === undefined) {
+          return false;
+        }
+        return exactMatchShapeAgainstDef(propValue, prop.typeAnnotation);
+      });
+    }
+    return false;
+  }
+  return false;
+}
+
+function inferTypeConstructorAgainstTypeKey(value, typeKey) {
+  const def = typeDefinitionMap[typeKey];
+  if (!def) {
+    return undefined;
+  }
+  if (def.typeKind === "primitive" && def.concept !== "Enum") {
+    // 视作没有Constructor
+    return undefined;
+  }
+  if (def.typeKind === "union") {
+    // Union的所有分支对应的类型构造器，从左到右匹配：
+    // 1. 对当前类型构造器，看它有无定义tag字段：有tag字段且值和value对应字段相同，直接输出当前类型构造器；否则，跳过。
+    // 2. 先判断结构是否一致（复合类型递归看properties属性；Primitive类型直接判断即可）。结构相同的时候，当前类型构造器作为候选；否则，跳过。
+    // 输出：第一个候选，或者无匹配
+    let candidate = undefined;
+    for (const ty of def.typeArguments) {
+      const curTypeKey = `${ty.typeNamespace}.${ty.typeName}`;
+      const curDef = typeDefinitionMap[curTypeKey];
+      if (
+        ty.typeKind === "primitive" &&
+        exactMatchShapeAgainstDef(value, curDef)
+      ) {
+        // 匹配上了Primitve类型
+        return typeMap[curTypeKey];
+      } else if (ty.typeKind === "union") {
+        // 不可以出现嵌套union类型
+        return undefined;
+      } else if (ty.typeKind === "reference") {
+        const properties = typeDefinitionMap[curTypeKey]?.properties;
+        if (properties) {
+          // 如果存在字段定义，那么尝试获取第一个tag字段
+          const tagProperty = properties
+            .flatMap((prop) => {
+              const defaultValue = prop.defaultValue;
+              const hardcodedPropertyName = "errorType";
+              if (
+                prop.name === hardcodedPropertyName &&
+                defaultValue?.expression?.concept === "StringLiteral"
+              ) {
+                return [
+                  // 注意：允许tagValue为undefined
+                  { name: prop.name, tagValue: defaultValue.expression.value },
+                ];
+              }
+              return [];
+            })
+            .at(0);
+          if (tagProperty) {
+            if (
+              tagProperty.tagValue === value?.[tagProperty.name] &&
+              exactMatchShapeAgainstDef(value, curDef)
+            ) {
+              return typeMap[curTypeKey];
+            }
+          } else if (exactMatchShapeAgainstDef(value, curDef)) {
+            candidate = typeMap[curTypeKey];
+          }
+        }
+      }
+    }
+    return candidate;
+  }
+  return typeMap[typeKey];
+}
+
 /**
  * 初始化变量
  * 基础类型不再进初始化方法
@@ -428,9 +543,15 @@ export const genInitData = (typeKey, defaultValue, parentLevel?) => {
       }
       return parsedValue;
     } else if (typeKey) {
-      const TypeConstructor = typeMap[typeKey];
-      if (TypeConstructor && !["primitive", "union"].includes(typeKind) && concept !== "Enum") {
-        if (concept === "Structure" && Object.prototype.toString.call(parsedValue) === "[object Object]") {
+      const TypeConstructor = inferTypeConstructorAgainstTypeKey(
+        parsedValue,
+        typeKey
+      );
+      if (TypeConstructor) {
+        if (
+          concept === "Structure" &&
+          Object.prototype.toString.call(parsedValue) === "[object Object]"
+        ) {
           parsedValue = jsonNameReflection(properties, parsedValue);
         }
         const instance = new TypeConstructor({
@@ -441,9 +562,7 @@ export const genInitData = (typeKey, defaultValue, parentLevel?) => {
       }
     }
   }
-  if (parsedValue !== undefined) {
-    return parsedValue;
-  }
+  return parsedValue;
 };
 
 /**

--- a/packages/basic/src/init/dataTypes/tools.ts
+++ b/packages/basic/src/init/dataTypes/tools.ts
@@ -407,7 +407,7 @@ function exactMatchShapeAgainstDef(value, def: any): boolean {
 
 function inferTypeConstructorAgainstTypeKey(value, typeKey) {
   const def = typeDefinitionMap[typeKey];
-  if (!def) {
+  if (!def || value === undefined) {
     return undefined;
   }
   if (def.typeKind === "primitive" && def.concept !== "Enum") {

--- a/packages/basic/src/init/dataTypes/tools.ts
+++ b/packages/basic/src/init/dataTypes/tools.ts
@@ -371,7 +371,7 @@ function exactMatchShapeAgainstDef(value, def: any): boolean {
       (isDefString(typeKey) && valueTypeStr === "[object String]")
     );
   }
-  if (!def) {
+  if (!def || value === undefined) {
     return false;
   }
   if (value === null) {
@@ -393,7 +393,7 @@ function exactMatchShapeAgainstDef(value, def: any): boolean {
     const properties = def.properties;
     if (properties) {
       return properties.every((prop) => {
-        const propValue = value[prop.name];
+        const propValue = value?.[prop.name];
         if (propValue === undefined) {
           return false;
         }

--- a/packages/basic/src/init/dataTypes/tools.ts
+++ b/packages/basic/src/init/dataTypes/tools.ts
@@ -459,7 +459,7 @@ function inferTypeConstructorAgainstTypeKey(value, typeKey) {
             ) {
               return typeMap[curTypeKey];
             }
-          } else if (exactMatchShapeAgainstDef(value, curDef)) {
+          } else if (candidate === undefined && exactMatchShapeAgainstDef(value, curDef)) {
             candidate = typeMap[curTypeKey];
           }
         }

--- a/packages/basic/src/init/dataTypes/tools.ts
+++ b/packages/basic/src/init/dataTypes/tools.ts
@@ -366,7 +366,7 @@ function exactMatchShapeAgainstDef(value, def: any): boolean {
     }
     const typeKey = `${ty.typeNamespace}.${ty.typeName}`;
     return (
-      (ty === "nasl.core.Boolean" && valueTypeStr === "[object Boolean]") ||
+      (typeKey === "nasl.core.Boolean" && valueTypeStr === "[object Boolean]") ||
       (isDefNumber(typeKey) && valueTypeStr === "[object Number]") ||
       (isDefString(typeKey) && valueTypeStr === "[object String]")
     );

--- a/packages/basic/tests/init/dataTypes/union.spec.js
+++ b/packages/basic/tests/init/dataTypes/union.spec.js
@@ -1,0 +1,292 @@
+// @ts-check
+import { genInitFromSchema, global, initDataTypes } from "../../../src";
+import { typeDefinitionMap } from "../../../src/init/dataTypes/tools";
+
+describe("genInitFromSchema支持tagged-union", () => {
+  let sandbox = {};
+
+  const unionTypeKey =
+    "nasl.error.InterfaceError | nasl.error.DatabaseError | nasl.core.String";
+  beforeAll(() => {
+    jest.resetModules();
+    initDataTypes({
+      dataTypesMap: {
+        "nasl.error.InterfaceError | nasl.error.DatabaseError | nasl.core.String":
+          {
+            concept: "TypeAnnotation",
+            typeKind: "union",
+            typeArguments: [
+              {
+                concept: "TypeAnnotation",
+                typeKind: "reference",
+                typeName: "InterfaceError",
+                typeNamespace: "nasl.error",
+              },
+              {
+                concept: "TypeAnnotation",
+                typeKind: "reference",
+                typeName: "DatabaseError",
+                typeNamespace: "nasl.error",
+              },
+              {
+                concept: "TypeAnnotation",
+                typeKind: "primitive",
+                typeName: "String",
+                typeNamespace: "nasl.core",
+              },
+            ],
+          },
+        "nasl.error.DatabaseError": {
+          concept: "Structure",
+          name: "DatabaseError",
+          properties: [
+            {
+              concept: "StructureProperty",
+              name: "errorMsg",
+              typeAnnotation: {
+                concept: "TypeAnnotation",
+                typeKind: "primitive",
+                typeNamespace: "nasl.core",
+                typeName: "String",
+              },
+            },
+            {
+              concept: "StructureProperty",
+              name: "errorType",
+              typeAnnotation: {
+                concept: "TypeAnnotation",
+                typeKind: "primitive",
+                typeNamespace: "nasl.core",
+                typeName: "String",
+              },
+              defaultValue: {
+                concept: "DefaultValue",
+                expression: {
+                  concept: "StringLiteral",
+                  value: "nasl.error.DatabaseError",
+                  folded: false,
+                },
+                playground: [],
+              },
+              defaultCode: {
+                code: "`nasl.error.DatabaseError`",
+                executeCode: true,
+              },
+            },
+          ],
+        },
+        "nasl.error.InterfaceError": {
+          concept: "Structure",
+          name: "InterfaceError",
+          properties: [
+            {
+              concept: "StructureProperty",
+              name: "errorType",
+              typeAnnotation: {
+                concept: "TypeAnnotation",
+                typeKind: "primitive",
+                typeNamespace: "nasl.core",
+                typeName: "String",
+              },
+              defaultValue: {
+                concept: "DefaultValue",
+                expression: {
+                  concept: "StringLiteral",
+                  value: "nasl.error.InterfaceError",
+                  folded: false,
+                },
+                playground: [],
+              },
+              defaultCode: {
+                code: "`nasl.error.InterfaceError`",
+                executeCode: true,
+              },
+            },
+            {
+              concept: "StructureProperty",
+              name: "errorMsg",
+              typeAnnotation: {
+                concept: "TypeAnnotation",
+                typeKind: "primitive",
+                typeNamespace: "nasl.core",
+                typeName: "String",
+              },
+            },
+            {
+              concept: "StructureProperty",
+              name: "responseBody",
+              typeAnnotation: {
+                concept: "TypeAnnotation",
+                typeKind: "primitive",
+                typeNamespace: "nasl.core",
+                typeName: "String",
+              },
+            },
+            {
+              concept: "StructureProperty",
+              name: "statusCode",
+              typeAnnotation: {
+                concept: "TypeAnnotation",
+                typeKind: "primitive",
+                typeNamespace: "nasl.core",
+                typeName: "String",
+              },
+            },
+          ],
+        },
+      },
+    });
+    sandbox = {
+      singlyTypedDatabaseError: genInitFromSchema("nasl.error.DatabaseError", {
+        errorType: "nasl.error.DatabaseError",
+        errorMsg: "测试",
+      }),
+      unionTypedDatabaseError: genInitFromSchema(unionTypeKey, {
+        errorType: "nasl.error.DatabaseError",
+        errorMsg: "测试",
+      }),
+    };
+  });
+  describe("测试genInitFromSchema返回的值符合预期", () => {
+    test("union类型的实例对象形状正确", () => {
+      expect(sandbox.unionTypedDatabaseError).toEqual({
+        errorType: "nasl.error.DatabaseError",
+        errorMsg: "测试",
+      });
+    });
+    test("单类型的实例对象形状正确", () => {
+      expect(sandbox.singlyTypedDatabaseError).toEqual({
+        errorType: "nasl.error.DatabaseError",
+        errorMsg: "测试",
+      });
+    });
+    test("单类型的实例和Union类型的实例的TypeConstructor一致，Union类型没有自己的TypeConstructor", () => {
+      expect(sandbox.singlyTypedDatabaseError.constructor.toString()).toBe(
+        sandbox.unionTypedDatabaseError.constructor.toString()
+      );
+    });
+  });
+  describe("测试typeDefinitionMap能够包含union类型的定义", () => {
+    test("支持union类型的typeKey", () => {
+      const def = typeDefinitionMap[unionTypeKey];
+      expect(def).toEqual({
+        concept: "TypeAnnotation",
+        typeKind: "union",
+        typeArguments: [
+          {
+            concept: "TypeAnnotation",
+            typeKind: "reference",
+            typeName: "InterfaceError",
+            typeNamespace: "nasl.error",
+          },
+          {
+            concept: "TypeAnnotation",
+            typeKind: "reference",
+            typeName: "DatabaseError",
+            typeNamespace: "nasl.error",
+          },
+          {
+            concept: "TypeAnnotation",
+            typeKind: "primitive",
+            typeName: "String",
+            typeNamespace: "nasl.core",
+          },
+        ],
+      });
+    });
+  });
+  describe("子类型性质", () => {
+    test("单类型的项的子类型性质", () => {
+      expect(
+        global.$isInstanceOf(sandbox.singlyTypedDatabaseError, unionTypeKey)
+      ).toBe(true);
+      expect(
+        global.$isInstanceOf(
+          sandbox.singlyTypedDatabaseError,
+          "nasl.error.DatabaseError"
+        )
+      ).toBe(true);
+    });
+    test("Union类型的项的子类型性质", () => {
+      expect(
+        global.$isInstanceOf(
+          sandbox.unionTypedDatabaseError,
+          "nasl.error.DatabaseError"
+        )
+      ).toBe(true);
+      expect(
+        global.$isInstanceOf(sandbox.unionTypedDatabaseError, unionTypeKey)
+      ).toBe(true);
+      expect(
+        global.$isInstanceOf(
+          sandbox.unionTypedDatabaseError,
+          "nasl.core.String"
+        )
+      ).toBe(false);
+      expect(
+        global.$isInstanceOf(
+          sandbox.unionTypedDatabaseError,
+          "nasl.error.InterfaceError"
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe("字段为空的情形", () => {
+    test("字段为null时，所属的构造器仍然正确", () => {
+      const unionTypedDatabaseErrorWithNull = genInitFromSchema(unionTypeKey, {
+        errorType: "nasl.error.DatabaseError",
+        errorMsg: null,
+      });
+      expect(
+        global.$isInstanceOf(
+          unionTypedDatabaseErrorWithNull,
+          "nasl.error.DatabaseError"
+        )
+      ).toBe(true);
+      expect(
+        global.$isInstanceOf(unionTypedDatabaseErrorWithNull, unionTypeKey)
+      ).toBe(true);
+    });
+  });
+
+  describe("形状和union的第一个分支无法完全match", () => {
+    test("尊重tag", () => {
+      const unionTypedInterfaceErrorWithNull = genInitFromSchema(unionTypeKey, {
+        errorType: "nasl.error.DatabaseError",
+        errorMsg: null,
+        responseBody: null,
+        statusCode: null,
+      });
+      expect(
+        global.$isInstanceOf(
+          unionTypedInterfaceErrorWithNull,
+          "nasl.error.DatabaseError"
+        )
+      ).toBe(true);
+      expect(
+        global.$isInstanceOf(unionTypedInterfaceErrorWithNull, unionTypeKey)
+      ).toBe(true);
+    });
+  });
+});
+
+describe("genInitFromSchema支持形状推断算法", () => {
+  describe("同构推断，优先返回第一个", () => {
+    test.todo(
+      "Entity1{a: String} | Entity2{a: String} | Entity3{a: String} | String"
+    );
+    test.todo(
+      "Entity2{a: String} | Entity1{a: String} | Entity3{a: String} | String"
+    );
+  });
+  describe("非同构推断", () => {
+    test.todo("Entity1 | Entity2 | String | Boolean");
+    test.todo("Entity1 | Boolean");
+  });
+  describe("复杂形状的同构推断", () => {
+    test.todo(
+      "Entity1{list: List<Entity1>} | Entity2{list: List<Entity2>} | Boolean"
+    );
+  });
+});


### PR DESCRIPTION
## 特性
1. genInitFromSchema支持Union类型。特别地，支持使用DefaultValue实现的StringLiteral的Tag机制，来对传入的对象打分以确定这个对象属于Union的哪个分支。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced new functions for enhanced type checking and constructor inference.
	- Improved logic for type initialization and matching.
- **Bug Fixes**
	- Refined handling of default values and union types in initialization.
- **Tests**
	- Added a comprehensive test suite for validating the `genInitFromSchema` function with union types and shape inference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->