### PR TITLE
fix: 修复Vue应用导出源码,basic初始化时拿不到window.Vue

### DIFF
--- a/packages/basic/src/global.ts
+++ b/packages/basic/src/global.ts
@@ -1,6 +1,7 @@
 import _set from "lodash/set";
 
 // 用来mock Vue的构造函数
+// @ts-ignore
 const GlobalFn = window.Vue || function MockVue() {};
 
 export default GlobalFn;

--- a/packages/basic/src/types/global.ts
+++ b/packages/basic/src/types/global.ts
@@ -17,7 +17,6 @@ interface Window {
   postRequest: any;
   axiosOptionsSetup: (options: any) => void;
   $i18n: any;
-  Vue: any;
 }
 
 // navigator对象

--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -2,7 +2,8 @@ import Vue from "vue";
 
 declare global {
   interface Window {
-    appVue: typeof Vue;
+    appVue: any;
+    Vue: any;
   }
 }
 

--- a/packages/core/src/global.ts
+++ b/packages/core/src/global.ts
@@ -1,0 +1,10 @@
+import Vue from "vue";
+
+declare global {
+  interface Window {
+    appVue: typeof Vue;
+  }
+}
+
+window.appVue = Vue;
+window.Vue = Vue;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+import "./global";
 import filters from "./filters";
 import * as directives from "./directives";
 export * from "./mixins";

--- a/packages/h5/src/init.js
+++ b/packages/h5/src/init.js
@@ -45,8 +45,6 @@ Vue.prototype.$sleep = function () {
 };
 
 window._lcapCreateService = createService;
-window.appVue = Vue;
-window.Vue = Vue;
 window.LcapInstall = install;
 
 installOptions(Vue);

--- a/packages/pc/src/init.js
+++ b/packages/pc/src/init.js
@@ -41,8 +41,6 @@ Vue.prototype.$sleep = function () {
 };
 
 window._lcapCreateService = createService;
-window.appVue = Vue;
-window.Vue = Vue;
 window.LcapInstall = install;
 
 installOptions(Vue);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced global access to the Vue instance via `window.appVue` and `window.Vue`.
	- Enhanced internationalization support with improved locale detection and fallback mechanisms.
	- Added authentication checks in the routing process for better security.
	- Implemented a mock Vue constructor for environments where Vue is unavailable.

- **Bug Fixes**
	- Improved error handling during application initialization and routing transitions.

- **Chores**
	- Updated favicon setup logic based on platform configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->