### PR TITLE
fix: 为了和安卓WebView的兼容性避免使用.at & .flatMap

### DIFF
--- a/packages/basic/src/init/dataTypes/tools.ts
+++ b/packages/basic/src/init/dataTypes/tools.ts
@@ -1,7 +1,7 @@
 import { format } from "date-fns";
 import momentTZ from "moment-timezone";
 import moment from "moment";
-import { xor } from "lodash";
+import { flatMap, xor } from "lodash";
 
 import { getAppTimezone, safeNewDate } from "../utils";
 import Config from "../../config";
@@ -445,19 +445,17 @@ function inferTypeConstructorAgainstTypeKey(value, typeKey) {
         const properties = typeDefinitionMap[curTypeKey]?.properties;
         if (properties) {
           // 如果存在字段定义，那么尝试获取第一个tag字段
-          const tagProperty = properties
-            .flatMap((prop) => {
-              const defaultValue = prop.defaultValue;
-              const hardcodedPropertyName = "errorType";
-              if (prop.name === hardcodedPropertyName && defaultValue?.expression?.concept === "StringLiteral") {
-                return [
-                  // 注意：允许tagValue为undefined
-                  { name: prop.name, tagValue: defaultValue.expression.value },
-                ];
-              }
-              return [];
-            })
-            .at(0);
+          const tagProperty = flatMap(properties, (prop) => {
+            const defaultValue = prop.defaultValue;
+            const hardcodedPropertyName = "errorType";
+            if (prop.name === hardcodedPropertyName && defaultValue?.expression?.concept === "StringLiteral") {
+              return [
+                // 注意：允许tagValue为undefined
+                { name: prop.name, tagValue: defaultValue.expression.value },
+              ];
+            }
+            return [];
+          })?.[0];
           if (tagProperty && tagProperty.tagValue === value?.[tagProperty.name]) {
             return typeMap[curTypeKey];
           } else if (candidate === undefined && exactMatchShapeAgainstDef(value, curDef)) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **样式调整**
	- 优化了代码中的导入语句
	- 使用 `lodash` 库的 `flatMap` 函数简化了数组处理逻辑
	- 改进了代码可读性，减少了潜在的未定义值错误

<!-- end of auto-generated comment: release notes by coderabbit.ai -->